### PR TITLE
E_WARNING

### DIFF
--- a/page.epm_oss.php
+++ b/page.epm_oss.php
@@ -1,7 +1,7 @@
 <?php
 global $active_modules;
 
-if (!empty($active_modules[endpoint][rawname])) {
+if (!empty($active_modules['endpoint']['rawname'])) {
 	if (FreePBX::Endpointman()->configmod->get("disable_endpoint_warning") !== "1") {
 		include('page.epm_warning.php');  
 	}


### PR DESCRIPTION
Use of undefined constant endpoint - assumed 'endpoint' (this will throw an Error in a future version of PHP) i get this E_WARNING when using php7.3